### PR TITLE
Refactor Fix/FixVector to make initialization from raw values more explicit

### DIFF
--- a/LibDescent/Data/Fix.cs
+++ b/LibDescent/Data/Fix.cs
@@ -27,7 +27,7 @@ namespace LibDescent.Data
     {
         private int value;
 
-        public static implicit operator int(Fix f)
+        public static explicit operator int(Fix f)
             => f.value / 65536;
         public static implicit operator Fix(int i)
             => FromRawValue(i * 65536);
@@ -62,6 +62,8 @@ namespace LibDescent.Data
 
         public static Fix operator <<(Fix a, int shift) => FromRawValue(a.value << shift);
         public static Fix operator >>(Fix a, int shift) => FromRawValue(a.value >> shift);
+        public static bool operator ==(Fix a, Fix b) => a.value == b.value;
+        public static bool operator !=(Fix a, Fix b) => a.value != b.value;
 
         public override string ToString()
         {
@@ -79,6 +81,17 @@ namespace LibDescent.Data
             {
                 value = value
             };
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is Fix fix &&
+                   value == fix.value;
+        }
+
+        public override int GetHashCode()
+        {
+            return -1584136870 + value.GetHashCode();
         }
     }
 }

--- a/LibDescent/Data/Fix.cs
+++ b/LibDescent/Data/Fix.cs
@@ -27,42 +27,41 @@ namespace LibDescent.Data
     {
         private int value;
 
-        public Fix(int rawValue)
-        {
-            value = rawValue;
-        }
-
+        public static implicit operator int(Fix f)
+            => f.value / 65536;
+        public static implicit operator Fix(int i)
+            => FromRawValue(i * 65536);
         public static implicit operator float(Fix f)
             => f.value / 65536.0f;
         public static implicit operator Fix(float d)
-            => new Fix((int)(d * 65536.0f));
+            => FromRawValue((int)(d * 65536.0f));
         public static implicit operator double(Fix f)
             => f.value / 65536.0;
         public static implicit operator Fix(double d)
-            => new Fix((int)(d * 65536.0));
+            => FromRawValue((int)(d * 65536.0));
 
         public static Fix operator +(Fix a)
-            => new Fix(a.value);
+            => FromRawValue(a.value);
         public static Fix operator -(Fix a)
-            => new Fix(-a.value);
+            => FromRawValue(-a.value);
         public static Fix operator +(Fix a, Fix b)
-            => new Fix(a.value + b.value);
+            => FromRawValue(a.value + b.value);
         public static Fix operator -(Fix a, Fix b)
-            => new Fix(a.value - b.value);
+            => FromRawValue(a.value - b.value);
 
         public static Fix operator *(Fix a, Fix b)
         {
             long product = (long)a.value * (long)b.value;
-            return new Fix((int)(product >> 16));
+            return FromRawValue((int)(product >> 16));
         }
         public static Fix operator /(Fix a, Fix b)
         {
             long quotient = ((long)a.value << 16) / (long)b.value;
-            return new Fix((int)quotient);
+            return FromRawValue((int)quotient);
         }
 
-        public static Fix operator <<(Fix a, int shift) => new Fix(a.value << shift);
-        public static Fix operator >>(Fix a, int shift) => new Fix(a.value >> shift);
+        public static Fix operator <<(Fix a, int shift) => FromRawValue(a.value << shift);
+        public static Fix operator >>(Fix a, int shift) => FromRawValue(a.value >> shift);
 
         public override string ToString()
         {
@@ -72,6 +71,14 @@ namespace LibDescent.Data
         public int GetRawValue()
         {
             return value;
+        }
+
+        public static Fix FromRawValue(int value)
+        {
+            return new Fix
+            {
+                value = value
+            };
         }
     }
 }

--- a/LibDescent/Data/Fix.cs
+++ b/LibDescent/Data/Fix.cs
@@ -30,29 +30,29 @@ namespace LibDescent.Data
         public static explicit operator int(Fix f)
             => f.value / 65536;
         public static implicit operator Fix(int i)
-            => FromRawValue(i * 65536);
+            => FromRawValue(checked(i * 65536));
         public static implicit operator float(Fix f)
             => f.value / 65536.0f;
         public static implicit operator Fix(float d)
-            => FromRawValue((int)(d * 65536.0f));
+            => FromRawValue(checked((int)(d * 65536.0f)));
         public static implicit operator double(Fix f)
             => f.value / 65536.0;
         public static implicit operator Fix(double d)
-            => FromRawValue((int)(d * 65536.0));
+            => FromRawValue(checked((int)(d * 65536.0)));
 
         public static Fix operator +(Fix a)
             => FromRawValue(a.value);
         public static Fix operator -(Fix a)
             => FromRawValue(-a.value);
         public static Fix operator +(Fix a, Fix b)
-            => FromRawValue(a.value + b.value);
+            => FromRawValue(checked(a.value + b.value));
         public static Fix operator -(Fix a, Fix b)
-            => FromRawValue(a.value - b.value);
+            => FromRawValue(checked(a.value - b.value));
 
         public static Fix operator *(Fix a, Fix b)
         {
             long product = (long)a.value * (long)b.value;
-            return FromRawValue((int)(product >> 16));
+            return FromRawValue(checked((int)(product >> 16)));
         }
         public static Fix operator /(Fix a, Fix b)
         {
@@ -60,7 +60,7 @@ namespace LibDescent.Data
             return FromRawValue((int)quotient);
         }
 
-        public static Fix operator <<(Fix a, int shift) => FromRawValue(a.value << shift);
+        public static Fix operator <<(Fix a, int shift) => FromRawValue(checked(a.value << shift));
         public static Fix operator >>(Fix a, int shift) => FromRawValue(a.value >> shift);
         public static bool operator ==(Fix a, Fix b) => a.value == b.value;
         public static bool operator !=(Fix a, Fix b) => a.value != b.value;

--- a/LibDescent/Data/FixVector.cs
+++ b/LibDescent/Data/FixVector.cs
@@ -34,14 +34,14 @@ namespace LibDescent.Data
         public Fix y;
         public Fix z;
 
-        public FixVector(int x, int y, int z)
-        {
-            this.x = new Fix(x); this.y = new Fix(y); this.z = new Fix(z);
-        }
-        
         public FixVector(Fix x, Fix y, Fix z)
         {
             this.x = x; this.y = y; this.z = z;
+        }
+
+        public static FixVector FromRawValues(int x, int y, int z)
+        {
+            return new FixVector(Fix.FromRawValue(x), Fix.FromRawValue(y), Fix.FromRawValue(z));
         }
 
         public override string ToString()

--- a/LibDescent/Data/FixVector.cs
+++ b/LibDescent/Data/FixVector.cs
@@ -20,6 +20,7 @@
     SOFTWARE.
 */
 using System;
+using System.Numerics;
 
 namespace LibDescent.Data
 {
@@ -43,6 +44,11 @@ namespace LibDescent.Data
         {
             return new FixVector(Fix.FromRawValue(x), Fix.FromRawValue(y), Fix.FromRawValue(z));
         }
+
+        public static explicit operator Vector3(FixVector v)
+            => new Vector3(v.x, v.y, v.z);
+        public static implicit operator FixVector(Vector3 v)
+            => new FixVector(v.X, v.Y, v.Z);
 
         public override string ToString()
         {

--- a/LibDescent/Data/HAMDataReader.cs
+++ b/LibDescent/Data/HAMDataReader.cs
@@ -31,8 +31,8 @@ namespace LibDescent.Data
             TMAPInfo mapinfo = new TMAPInfo();
             mapinfo.flags = br.ReadByte();
             br.ReadBytes(3);
-            mapinfo.lighting = new Fix(br.ReadInt32());
-            mapinfo.damage = new Fix(br.ReadInt32());
+            mapinfo.lighting = Fix.FromRawValue(br.ReadInt32());
+            mapinfo.damage = Fix.FromRawValue(br.ReadInt32());
             mapinfo.eclip_num = br.ReadInt16();
             mapinfo.destroyed = br.ReadInt16();
             mapinfo.slide_u = br.ReadInt16();
@@ -44,16 +44,16 @@ namespace LibDescent.Data
         public VClip ReadVClip(BinaryReader br)
         {
             VClip clip = new VClip();
-            clip.play_time = new Fix(br.ReadInt32());
+            clip.play_time = Fix.FromRawValue(br.ReadInt32());
             clip.num_frames = br.ReadInt32();
-            clip.frame_time = new Fix(br.ReadInt32());
+            clip.frame_time = Fix.FromRawValue(br.ReadInt32());
             clip.flags = br.ReadInt32();
             clip.sound_num = br.ReadInt16();
             for (int f = 0; f < 30; f++)
             {
                 clip.frames[f] = br.ReadUInt16();
             }
-            clip.light_value = new Fix(br.ReadInt32());
+            clip.light_value = Fix.FromRawValue(br.ReadInt32());
 
             return clip;
         }
@@ -61,16 +61,16 @@ namespace LibDescent.Data
         public EClip ReadEClip(BinaryReader br)
         {
             EClip clip = new EClip();
-            clip.vc.play_time = new Fix(br.ReadInt32());
+            clip.vc.play_time = Fix.FromRawValue(br.ReadInt32());
             clip.vc.num_frames = br.ReadInt32();
-            clip.vc.frame_time = new Fix(br.ReadInt32());
+            clip.vc.frame_time = Fix.FromRawValue(br.ReadInt32());
             clip.vc.flags = br.ReadInt32();
             clip.vc.sound_num = br.ReadInt16();
             for (int f = 0; f < 30; f++)
             {
                 clip.vc.frames[f] = br.ReadUInt16();
             }
-            clip.vc.light_value = new Fix(br.ReadInt32());
+            clip.vc.light_value = Fix.FromRawValue(br.ReadInt32());
             clip.time_left = br.ReadInt32();
             clip.frame_count = br.ReadInt32();
             clip.changing_wall_texture = br.ReadInt16();
@@ -80,7 +80,7 @@ namespace LibDescent.Data
             clip.dest_bm_num = br.ReadInt32();
             clip.dest_vclip = br.ReadInt32();
             clip.dest_eclip = br.ReadInt32();
-            clip.dest_size = new Fix(br.ReadInt32());
+            clip.dest_size = Fix.FromRawValue(br.ReadInt32());
             clip.sound_num = br.ReadInt32();
             clip.segnum = br.ReadInt32();
             clip.sidenum = br.ReadInt32();
@@ -91,7 +91,7 @@ namespace LibDescent.Data
         public WClip ReadWClip(BinaryReader br)
         {
             WClip clip = new WClip();
-            clip.play_time = new Fix(br.ReadInt32());
+            clip.play_time = Fix.FromRawValue(br.ReadInt32());
             clip.num_frames = br.ReadInt16();
             for (int f = 0; f < 50; f++)
             {
@@ -116,7 +116,7 @@ namespace LibDescent.Data
 
             for (int s = 0; s < Polymodel.MAX_GUNS; s++)
             {
-                robot.gun_points[s] = new FixVector(br.ReadInt32(), br.ReadInt32(), br.ReadInt32());
+                robot.gun_points[s] = FixVector.FromRawValues(br.ReadInt32(), br.ReadInt32(), br.ReadInt32());
             }
             for (int s = 0; s < 8; s++)
             {
@@ -142,34 +142,34 @@ namespace LibDescent.Data
             robot.badass = br.ReadByte();
             robot.energy_drain = br.ReadByte();
             
-            robot.lighting = new Fix(br.ReadInt32());
-            robot.strength = new Fix(br.ReadInt32());
+            robot.lighting = Fix.FromRawValue(br.ReadInt32());
+            robot.strength = Fix.FromRawValue(br.ReadInt32());
             
-            robot.mass = new Fix(br.ReadInt32());
-            robot.drag = new Fix(br.ReadInt32());
+            robot.mass = Fix.FromRawValue(br.ReadInt32());
+            robot.drag = Fix.FromRawValue(br.ReadInt32());
             for (int s = 0; s < Robot.NUM_DIFFICULTY_LEVELS; s++)
             {
-                robot.field_of_view[s] = new Fix(br.ReadInt32());
+                robot.field_of_view[s] = Fix.FromRawValue(br.ReadInt32());
             }
             for (int s = 0; s < Robot.NUM_DIFFICULTY_LEVELS; s++)
             {
-                robot.firing_wait[s] = new Fix(br.ReadInt32());
+                robot.firing_wait[s] = Fix.FromRawValue(br.ReadInt32());
             }
             for (int s = 0; s < Robot.NUM_DIFFICULTY_LEVELS; s++)
             {
-                robot.firing_wait2[s] = new Fix(br.ReadInt32());
+                robot.firing_wait2[s] = Fix.FromRawValue(br.ReadInt32());
             }
             for (int s = 0; s < Robot.NUM_DIFFICULTY_LEVELS; s++)
             {
-                robot.turn_time[s] = new Fix(br.ReadInt32());
+                robot.turn_time[s] = Fix.FromRawValue(br.ReadInt32());
             }
             for (int s = 0; s < Robot.NUM_DIFFICULTY_LEVELS; s++)
             {
-                robot.max_speed[s] = new Fix(br.ReadInt32());
+                robot.max_speed[s] = Fix.FromRawValue(br.ReadInt32());
             }
             for (int s = 0; s < Robot.NUM_DIFFICULTY_LEVELS; s++)
             {
-                robot.circle_distance[s] = new Fix(br.ReadInt32());
+                robot.circle_distance[s] = Fix.FromRawValue(br.ReadInt32());
             }
             for (int s = 0; s < Robot.NUM_DIFFICULTY_LEVELS; s++)
             {
@@ -252,31 +252,31 @@ namespace LibDescent.Data
 
             weapon.children = br.ReadSByte();
  
-            weapon.energy_usage = new Fix(br.ReadInt32());
-            weapon.fire_wait = new Fix(br.ReadInt32());
+            weapon.energy_usage = Fix.FromRawValue(br.ReadInt32());
+            weapon.fire_wait = Fix.FromRawValue(br.ReadInt32());
 
-            weapon.multi_damage_scale = new Fix(br.ReadInt32());
+            weapon.multi_damage_scale = Fix.FromRawValue(br.ReadInt32());
 
             weapon.bitmap = br.ReadUInt16();
             
-            weapon.blob_size = new Fix(br.ReadInt32());
-            weapon.flash_size = new Fix(br.ReadInt32());
-            weapon.impact_size = new Fix(br.ReadInt32());
+            weapon.blob_size = Fix.FromRawValue(br.ReadInt32());
+            weapon.flash_size = Fix.FromRawValue(br.ReadInt32());
+            weapon.impact_size = Fix.FromRawValue(br.ReadInt32());
             for (int s = 0; s < 5; s++)
             {
-                weapon.strength[s] = new Fix(br.ReadInt32());
+                weapon.strength[s] = Fix.FromRawValue(br.ReadInt32());
             }
             for (int s = 0; s < 5; s++)
             {
-                weapon.speed[s] = new Fix(br.ReadInt32());
+                weapon.speed[s] = Fix.FromRawValue(br.ReadInt32());
             }
-            weapon.mass = new Fix(br.ReadInt32());
-            weapon.drag = new Fix(br.ReadInt32());
-            weapon.thrust = new Fix(br.ReadInt32());
-            weapon.po_len_to_width_ratio = new Fix(br.ReadInt32());
-            weapon.light = new Fix(br.ReadInt32());
-            weapon.lifetime = new Fix(br.ReadInt32());
-            weapon.damage_radius = new Fix(br.ReadInt32());
+            weapon.mass = Fix.FromRawValue(br.ReadInt32());
+            weapon.drag = Fix.FromRawValue(br.ReadInt32());
+            weapon.thrust = Fix.FromRawValue(br.ReadInt32());
+            weapon.po_len_to_width_ratio = Fix.FromRawValue(br.ReadInt32());
+            weapon.light = Fix.FromRawValue(br.ReadInt32());
+            weapon.lifetime = Fix.FromRawValue(br.ReadInt32());
+            weapon.damage_radius = Fix.FromRawValue(br.ReadInt32());
 
             weapon.picture = br.ReadUInt16();
             weapon.hires_picture = br.ReadUInt16();
@@ -318,31 +318,31 @@ namespace LibDescent.Data
 
             weapon.children = 0;
 
-            weapon.energy_usage = new Fix(br.ReadInt32());
-            weapon.fire_wait = new Fix(br.ReadInt32());
+            weapon.energy_usage = Fix.FromRawValue(br.ReadInt32());
+            weapon.fire_wait = Fix.FromRawValue(br.ReadInt32());
 
             weapon.multi_damage_scale = 1;
 
             weapon.bitmap = br.ReadUInt16();
 
-            weapon.blob_size = new Fix(br.ReadInt32());
-            weapon.flash_size = new Fix(br.ReadInt32());
-            weapon.impact_size = new Fix(br.ReadInt32());
+            weapon.blob_size = Fix.FromRawValue(br.ReadInt32());
+            weapon.flash_size = Fix.FromRawValue(br.ReadInt32());
+            weapon.impact_size = Fix.FromRawValue(br.ReadInt32());
             for (int s = 0; s < 5; s++)
             {
-                weapon.strength[s] = new Fix(br.ReadInt32());
+                weapon.strength[s] = Fix.FromRawValue(br.ReadInt32());
             }
             for (int s = 0; s < 5; s++)
             {
-                weapon.speed[s] = new Fix(br.ReadInt32());
+                weapon.speed[s] = Fix.FromRawValue(br.ReadInt32());
             }
-            weapon.mass = new Fix(br.ReadInt32());
-            weapon.drag = new Fix(br.ReadInt32());
-            weapon.thrust = new Fix(br.ReadInt32());
-            weapon.po_len_to_width_ratio = new Fix(br.ReadInt32());
-            weapon.light = new Fix(br.ReadInt32());
-            weapon.lifetime = new Fix(br.ReadInt32());
-            weapon.damage_radius = new Fix(br.ReadInt32());
+            weapon.mass = Fix.FromRawValue(br.ReadInt32());
+            weapon.drag = Fix.FromRawValue(br.ReadInt32());
+            weapon.thrust = Fix.FromRawValue(br.ReadInt32());
+            weapon.po_len_to_width_ratio = Fix.FromRawValue(br.ReadInt32());
+            weapon.light = Fix.FromRawValue(br.ReadInt32());
+            weapon.lifetime = Fix.FromRawValue(br.ReadInt32());
+            weapon.damage_radius = Fix.FromRawValue(br.ReadInt32());
 
             weapon.picture = br.ReadUInt16();
             weapon.hires_picture = weapon.picture;
@@ -362,25 +362,25 @@ namespace LibDescent.Data
             }
             for (int s = 0; s < Polymodel.MAX_SUBMODELS; s++)
             {
-                model.submodels[s].Offset.x = new Fix(br.ReadInt32());
-                model.submodels[s].Offset.y = new Fix(br.ReadInt32());
-                model.submodels[s].Offset.z = new Fix(br.ReadInt32());
+                model.submodels[s].Offset.x = Fix.FromRawValue(br.ReadInt32());
+                model.submodels[s].Offset.y = Fix.FromRawValue(br.ReadInt32());
+                model.submodels[s].Offset.z = Fix.FromRawValue(br.ReadInt32());
             }
             for (int s = 0; s < Polymodel.MAX_SUBMODELS; s++)
             {
-                model.submodels[s].Normal.x = new Fix(br.ReadInt32());
-                model.submodels[s].Normal.y = new Fix(br.ReadInt32());
-                model.submodels[s].Normal.z = new Fix(br.ReadInt32());
+                model.submodels[s].Normal.x = Fix.FromRawValue(br.ReadInt32());
+                model.submodels[s].Normal.y = Fix.FromRawValue(br.ReadInt32());
+                model.submodels[s].Normal.z = Fix.FromRawValue(br.ReadInt32());
             }
             for (int s = 0; s < Polymodel.MAX_SUBMODELS; s++)
             {
-                model.submodels[s].Point.x = new Fix(br.ReadInt32());
-                model.submodels[s].Point.y = new Fix(br.ReadInt32());
-                model.submodels[s].Point.z = new Fix(br.ReadInt32());
+                model.submodels[s].Point.x = Fix.FromRawValue(br.ReadInt32());
+                model.submodels[s].Point.y = Fix.FromRawValue(br.ReadInt32());
+                model.submodels[s].Point.z = Fix.FromRawValue(br.ReadInt32());
             }
             for (int s = 0; s < Polymodel.MAX_SUBMODELS; s++)
             {
-                model.submodels[s].Radius = new Fix(br.ReadInt32());
+                model.submodels[s].Radius = Fix.FromRawValue(br.ReadInt32());
             }
             for (int s = 0; s < Polymodel.MAX_SUBMODELS; s++)
             {
@@ -391,23 +391,23 @@ namespace LibDescent.Data
             }
             for (int s = 0; s < Polymodel.MAX_SUBMODELS; s++)
             {
-                model.submodels[s].Mins.x = new Fix(br.ReadInt32());
-                model.submodels[s].Mins.y = new Fix(br.ReadInt32());
-                model.submodels[s].Mins.z = new Fix(br.ReadInt32());
+                model.submodels[s].Mins.x = Fix.FromRawValue(br.ReadInt32());
+                model.submodels[s].Mins.y = Fix.FromRawValue(br.ReadInt32());
+                model.submodels[s].Mins.z = Fix.FromRawValue(br.ReadInt32());
             }
             for (int s = 0; s < Polymodel.MAX_SUBMODELS; s++)
             {
-                model.submodels[s].Maxs.x = new Fix(br.ReadInt32());
-                model.submodels[s].Maxs.y = new Fix(br.ReadInt32());
-                model.submodels[s].Maxs.z = new Fix(br.ReadInt32());
+                model.submodels[s].Maxs.x = Fix.FromRawValue(br.ReadInt32());
+                model.submodels[s].Maxs.y = Fix.FromRawValue(br.ReadInt32());
+                model.submodels[s].Maxs.z = Fix.FromRawValue(br.ReadInt32());
             }
-            model.mins.x = new Fix(br.ReadInt32());
-            model.mins.y = new Fix(br.ReadInt32());
-            model.mins.z = new Fix(br.ReadInt32());
-            model.maxs.x = new Fix(br.ReadInt32());
-            model.maxs.y = new Fix(br.ReadInt32());
-            model.maxs.z = new Fix(br.ReadInt32());
-            model.rad = new Fix(br.ReadInt32());
+            model.mins.x = Fix.FromRawValue(br.ReadInt32());
+            model.mins.y = Fix.FromRawValue(br.ReadInt32());
+            model.mins.z = Fix.FromRawValue(br.ReadInt32());
+            model.maxs.x = Fix.FromRawValue(br.ReadInt32());
+            model.maxs.y = Fix.FromRawValue(br.ReadInt32());
+            model.maxs.z = Fix.FromRawValue(br.ReadInt32());
+            model.rad = Fix.FromRawValue(br.ReadInt32());
             model.n_textures = br.ReadByte();
             model.first_texture = br.ReadUInt16();
             model.simpler_model = br.ReadByte();

--- a/LibDescent/Data/HAMFile.cs
+++ b/LibDescent/Data/HAMFile.cs
@@ -229,8 +229,8 @@ namespace LibDescent.Data
                 Powerup powerup = new Powerup();
                 powerup.vclip_num = br.ReadInt32();
                 powerup.hit_sound = br.ReadInt32();
-                powerup.size = new Fix(br.ReadInt32());
-                powerup.light = new Fix(br.ReadInt32());
+                powerup.size = Fix.FromRawValue(br.ReadInt32());
+                powerup.light = Fix.FromRawValue(br.ReadInt32());
                 powerup.ID = x;
                 Powerups.Add(powerup);
             }
@@ -288,16 +288,16 @@ namespace LibDescent.Data
             PlayerShip = new Ship();
             PlayerShip.model_num = br.ReadInt32();
             PlayerShip.expl_vclip_num = br.ReadInt32();
-            PlayerShip.mass = new Fix(br.ReadInt32());
-            PlayerShip.drag = new Fix(br.ReadInt32());
-            PlayerShip.max_thrust = new Fix(br.ReadInt32());
-            PlayerShip.reverse_thrust = new Fix(br.ReadInt32());
-            PlayerShip.brakes = new Fix(br.ReadInt32());
-            PlayerShip.wiggle = new Fix(br.ReadInt32());
-            PlayerShip.max_rotthrust = new Fix(br.ReadInt32());
+            PlayerShip.mass = Fix.FromRawValue(br.ReadInt32());
+            PlayerShip.drag = Fix.FromRawValue(br.ReadInt32());
+            PlayerShip.max_thrust = Fix.FromRawValue(br.ReadInt32());
+            PlayerShip.reverse_thrust = Fix.FromRawValue(br.ReadInt32());
+            PlayerShip.brakes = Fix.FromRawValue(br.ReadInt32());
+            PlayerShip.wiggle = Fix.FromRawValue(br.ReadInt32());
+            PlayerShip.max_rotthrust = Fix.FromRawValue(br.ReadInt32());
             for (int x = 0; x < 8; x++)
             {
-                PlayerShip.gun_points[x] = new FixVector(br.ReadInt32(), br.ReadInt32(), br.ReadInt32());
+                PlayerShip.gun_points[x] = FixVector.FromRawValues(br.ReadInt32(), br.ReadInt32(), br.ReadInt32());
             }
             
             int NumCockpits = br.ReadInt32();
@@ -322,11 +322,11 @@ namespace LibDescent.Data
                 reactor.n_guns = br.ReadInt32();
                 for (int y = 0; y < 8; y++)
                 {
-                    reactor.gun_points[y] = new FixVector(br.ReadInt32(), br.ReadInt32(), br.ReadInt32());
+                    reactor.gun_points[y] = FixVector.FromRawValues(br.ReadInt32(), br.ReadInt32(), br.ReadInt32());
                 }
                 for (int y = 0; y < 8; y++)
                 {
-                    reactor.gun_dirs[y] = new FixVector(br.ReadInt32(), br.ReadInt32(), br.ReadInt32());
+                    reactor.gun_dirs[y] = FixVector.FromRawValues(br.ReadInt32(), br.ReadInt32(), br.ReadInt32());
                 }
                 Reactors.Add(reactor);
             }
@@ -517,7 +517,7 @@ namespace LibDescent.Data
             for (int i = 0; i < 8; i++)
             {
                 model.gunPoints[i] = ship.gun_points[i];
-                model.gunDirs[i] = new FixVector(65536, 0, 0);
+                model.gunDirs[i] = FixVector.FromRawValues(65536, 0, 0);
                 model.gunSubmodels[i] = 0;
             }
         }
@@ -544,7 +544,7 @@ namespace LibDescent.Data
             for (int i = 0; i < Polymodel.MAX_GUNS; i++)
             {
                 model.gunPoints[i] = robot.gun_points[i];
-                model.gunDirs[i] = new FixVector(65536, 0, 0);
+                model.gunDirs[i] = FixVector.FromRawValues(65536, 0, 0);
                 model.gunSubmodels[i] = robot.gun_submodels[i];
             }
             int[,] jointmapping = new int[10, 5];
@@ -1330,12 +1330,12 @@ namespace LibDescent.Data
                     for (int j = 0; j < model.numGuns; j++)
                     {
                         model.gunSubmodels[j] = br.ReadInt32();
-                        model.gunPoints[j].x = new Fix(br.ReadInt32());
-                        model.gunPoints[j].y = new Fix(br.ReadInt32());
-                        model.gunPoints[j].z = new Fix(br.ReadInt32());
-                        model.gunDirs[j].x = new Fix(br.ReadInt32());
-                        model.gunDirs[j].y = new Fix(br.ReadInt32());
-                        model.gunDirs[j].z = new Fix(br.ReadInt32());
+                        model.gunPoints[j].x = Fix.FromRawValue(br.ReadInt32());
+                        model.gunPoints[j].y = Fix.FromRawValue(br.ReadInt32());
+                        model.gunPoints[j].z = Fix.FromRawValue(br.ReadInt32());
+                        model.gunDirs[j].x = Fix.FromRawValue(br.ReadInt32());
+                        model.gunDirs[j].y = Fix.FromRawValue(br.ReadInt32());
+                        model.gunDirs[j].z = Fix.FromRawValue(br.ReadInt32());
                     }
                     model.isAnimated = br.ReadBoolean();
                     if (model.isAnimated)

--- a/LibDescent/Data/HXMFile.cs
+++ b/LibDescent/Data/HXMFile.cs
@@ -235,7 +235,7 @@ namespace LibDescent.Data
             for (int i = 0; i < Polymodel.MAX_GUNS; i++)
             {
                 model.gunPoints[i] = robot.gun_points[i];
-                model.gunDirs[i] = new FixVector(65536, 0, 0);
+                model.gunDirs[i] = FixVector.FromRawValues(65536, 0, 0);
                 model.gunSubmodels[i] = robot.gun_submodels[i];
             }
             int[,] jointmapping = new int[10, 5];

--- a/LibDescent/Data/POFReader.cs
+++ b/LibDescent/Data/POFReader.cs
@@ -69,7 +69,7 @@ namespace LibDescent.Data
                     case 1380206671:
                         {
                             model.n_models = br.ReadInt32();
-                            model.rad = new Fix(br.ReadInt32());
+                            model.rad = Fix.FromRawValue(br.ReadInt32());
                             model.mins = ReadVector(br);
                             model.maxs = ReadVector(br);
                             for (int i = 0; i < model.n_models; i++)
@@ -98,7 +98,7 @@ namespace LibDescent.Data
                                 submodel.Mins = ReadVector(br);
                                 submodel.Maxs = ReadVector(br);
                             }
-                            submodel.Radius = new Fix(br.ReadInt32());
+                            submodel.Radius = Fix.FromRawValue(br.ReadInt32());
                             submodel.Pointer = br.ReadInt32();
                             model.submodels.Add(submodel);
                             if (submodel.Parent != 255)
@@ -179,9 +179,9 @@ namespace LibDescent.Data
         {
             FixVector vec = new FixVector();
 
-            vec.x = new Fix(br.ReadInt32());
-            vec.y = new Fix(br.ReadInt32());
-            vec.z = new Fix(br.ReadInt32());
+            vec.x = Fix.FromRawValue(br.ReadInt32());
+            vec.y = Fix.FromRawValue(br.ReadInt32());
+            vec.z = Fix.FromRawValue(br.ReadInt32());
 
             return vec;
         }

--- a/LibDescent/Data/PolymodelData.cs
+++ b/LibDescent/Data/PolymodelData.cs
@@ -55,8 +55,8 @@ namespace LibDescent.Data
             BinaryReader br = new BinaryReader(ms);
             br.BaseStream.Seek(host.submodels[num].Pointer, SeekOrigin.Begin);
             short opcode = br.ReadInt16();
-            FixVector mins = new FixVector(int.MaxValue, int.MaxValue, int.MaxValue);
-            FixVector maxs = new FixVector(int.MinValue, int.MinValue, int.MinValue);
+            FixVector mins = FixVector.FromRawValues(int.MaxValue, int.MaxValue, int.MaxValue);
+            FixVector maxs = FixVector.FromRawValues(int.MinValue, int.MinValue, int.MinValue);
             switch (opcode)
             {
                 case 1:
@@ -66,9 +66,9 @@ namespace LibDescent.Data
                         for (int x = 0; x < pointc; x++)
                         {
                             FixVector point = new FixVector();
-                            point.x = new Fix(br.ReadInt32());
-                            point.y = new Fix(br.ReadInt32());
-                            point.z = new Fix(br.ReadInt32());
+                            point.x = Fix.FromRawValue(br.ReadInt32());
+                            point.y = Fix.FromRawValue(br.ReadInt32());
+                            point.z = Fix.FromRawValue(br.ReadInt32());
 
                             mins.x = Math.Min(mins.x, point.x);
                             mins.y = Math.Min(mins.y, point.y);
@@ -86,9 +86,9 @@ namespace LibDescent.Data
                         for (int x = 0; x < pointc; x++)
                         {
                             FixVector point = new FixVector();
-                            point.x = new Fix(br.ReadInt32());
-                            point.y = new Fix(br.ReadInt32());
-                            point.z = new Fix(br.ReadInt32());
+                            point.x = Fix.FromRawValue(br.ReadInt32());
+                            point.y = Fix.FromRawValue(br.ReadInt32());
+                            point.z = Fix.FromRawValue(br.ReadInt32());
 
                             mins.x = Math.Min(mins.x, point.x);
                             mins.y = Math.Min(mins.y, point.y);
@@ -167,9 +167,9 @@ namespace LibDescent.Data
                             for (int x = 0; x < pointc; x++)
                             {
                                 FixVector point = new FixVector();
-                                point.x = new Fix(br.ReadInt32());
-                                point.y = new Fix(br.ReadInt32());
-                                point.z = new Fix(br.ReadInt32());
+                                point.x = Fix.FromRawValue(br.ReadInt32());
+                                point.y = Fix.FromRawValue(br.ReadInt32());
+                                point.z = Fix.FromRawValue(br.ReadInt32());
                                 points[x] = point;
 
                             }
@@ -185,13 +185,13 @@ namespace LibDescent.Data
                             }
                             short pointc = br.ReadInt16(); //+2
                             FixVector vector = new FixVector();
-                            vector.x = new Fix(br.ReadInt32());
-                            vector.y = new Fix(br.ReadInt32());
-                            vector.z = new Fix(br.ReadInt32());
+                            vector.x = Fix.FromRawValue(br.ReadInt32());
+                            vector.y = Fix.FromRawValue(br.ReadInt32());
+                            vector.z = Fix.FromRawValue(br.ReadInt32());
                             FixVector normal = new FixVector();
-                            normal.x = new Fix(br.ReadInt32());
-                            normal.y = new Fix(br.ReadInt32());
-                            normal.z = new Fix(br.ReadInt32());
+                            normal.x = Fix.FromRawValue(br.ReadInt32());
+                            normal.y = Fix.FromRawValue(br.ReadInt32());
+                            normal.z = Fix.FromRawValue(br.ReadInt32());
                             short color = br.ReadInt16();
                             short[] pointindex = new short[pointc];
                             for (int x = 0; x < pointc; x++)
@@ -221,13 +221,13 @@ namespace LibDescent.Data
                             }
                             short pointc = br.ReadInt16(); //+2
                             FixVector vector = new FixVector();
-                            vector.x = new Fix(br.ReadInt32());
-                            vector.y = new Fix(br.ReadInt32());
-                            vector.z = new Fix(br.ReadInt32());
+                            vector.x = Fix.FromRawValue(br.ReadInt32());
+                            vector.y = Fix.FromRawValue(br.ReadInt32());
+                            vector.z = Fix.FromRawValue(br.ReadInt32());
                             FixVector normal = new FixVector();
-                            normal.x = new Fix(br.ReadInt32());
-                            normal.y = new Fix(br.ReadInt32());
-                            normal.z = new Fix(br.ReadInt32());
+                            normal.x = Fix.FromRawValue(br.ReadInt32());
+                            normal.y = Fix.FromRawValue(br.ReadInt32());
+                            normal.z = Fix.FromRawValue(br.ReadInt32());
                             short texture = br.ReadInt16();
                             if (sw != null)
                             {
@@ -247,9 +247,9 @@ namespace LibDescent.Data
                             for (int x = 0; x < pointc; x++)
                             {
                                 FixVector uvlcoords = new FixVector();
-                                uvlcoords.x = new Fix(br.ReadInt32());
-                                uvlcoords.y = new Fix(br.ReadInt32());
-                                uvlcoords.z = new Fix(br.ReadInt32());
+                                uvlcoords.x = Fix.FromRawValue(br.ReadInt32());
+                                uvlcoords.y = Fix.FromRawValue(br.ReadInt32());
+                                uvlcoords.z = Fix.FromRawValue(br.ReadInt32());
                                 uvlcoordlist[x] = uvlcoords;
                             }
                             FixVector[] pointdata = new FixVector[pointc];
@@ -271,13 +271,13 @@ namespace LibDescent.Data
                             long pos = br.BaseStream.Position - 2;
                             short n_points = br.ReadInt16();
                             FixVector vector = new FixVector();
-                            vector.x = new Fix(br.ReadInt32());
-                            vector.y = new Fix(br.ReadInt32());
-                            vector.z = new Fix(br.ReadInt32());
+                            vector.x = Fix.FromRawValue(br.ReadInt32());
+                            vector.y = Fix.FromRawValue(br.ReadInt32());
+                            vector.z = Fix.FromRawValue(br.ReadInt32());
                             FixVector norm = new FixVector();
-                            norm.x = new Fix(br.ReadInt32());
-                            norm.y = new Fix(br.ReadInt32());
-                            norm.z = new Fix(br.ReadInt32());
+                            norm.x = Fix.FromRawValue(br.ReadInt32());
+                            norm.y = Fix.FromRawValue(br.ReadInt32());
+                            norm.z = Fix.FromRawValue(br.ReadInt32());
                             Vector3 fvector = new Vector3((float)vector.x / 65536f, (float)vector.y / 65536f, (float)vector.z / 65536f);
                             Vector3 fnorm = new Vector3((float)norm.x / 65536f, (float)norm.y / 65536f, (float)norm.z / 65536f);
                             short zFront = br.ReadInt16();
@@ -335,12 +335,12 @@ namespace LibDescent.Data
                             long pos = br.BaseStream.Position - 2;
                             short objnum = br.ReadInt16();
                             //FixVector offset = new FixVector();
-                            host.submodels[objnum].RenderOffset.x = new Fix(br.ReadInt32());
-                            host.submodels[objnum].RenderOffset.y = new Fix(br.ReadInt32());
-                            host.submodels[objnum].RenderOffset.z = new Fix(br.ReadInt32());
-                            //offset.x = positionOffset.x + new Fix(br.ReadInt32());
-                            //offset.y = positionOffset.y + new Fix(br.ReadInt32());
-                            //offset.z = positionOffset.z + new Fix(br.ReadInt32());
+                            host.submodels[objnum].RenderOffset.x = Fix.FromRawValue(br.ReadInt32());
+                            host.submodels[objnum].RenderOffset.y = Fix.FromRawValue(br.ReadInt32());
+                            host.submodels[objnum].RenderOffset.z = Fix.FromRawValue(br.ReadInt32());
+                            //offset.x = positionOffset.x + Fix.FromRawValue(br.ReadInt32());
+                            //offset.y = positionOffset.y + Fix.FromRawValue(br.ReadInt32());
+                            //offset.z = positionOffset.z + Fix.FromRawValue(br.ReadInt32());
 
                             FixVector offset = positionOffset + host.submodels[objnum].RenderOffset;
                             ushort soffset = br.ReadUInt16();
@@ -384,9 +384,9 @@ namespace LibDescent.Data
                             for (int x = 0; x < pointc; x++)
                             {
                                 FixVector point = new FixVector();
-                                point.x = new Fix(br.ReadInt32());
-                                point.y = new Fix(br.ReadInt32());
-                                point.z = new Fix(br.ReadInt32());
+                                point.x = Fix.FromRawValue(br.ReadInt32());
+                                point.y = Fix.FromRawValue(br.ReadInt32());
+                                point.z = Fix.FromRawValue(br.ReadInt32());
                                 points[x + formerpoints] = point;
                                 //host.submodels[modelnum].points[x + formerpoints] = point;
                                 if (sw != null)
@@ -418,9 +418,9 @@ namespace LibDescent.Data
                             long pos = br.BaseStream.Position - 2;
                             short objnum = br.ReadInt16();
                             FixVector offset = new FixVector();
-                            offset.x = positionOffset.x + new Fix(br.ReadInt32());
-                            offset.y = positionOffset.y + new Fix(br.ReadInt32());
-                            offset.z = positionOffset.z + new Fix(br.ReadInt32());
+                            offset.x = positionOffset.x + Fix.FromRawValue(br.ReadInt32());
+                            offset.y = positionOffset.y + Fix.FromRawValue(br.ReadInt32());
+                            offset.z = positionOffset.z + Fix.FromRawValue(br.ReadInt32());
                             int soffset = br.ReadInt32();
                             long returnpos = br.BaseStream.Position;
                             if (sw != null)

--- a/LibDescent/Data/Robot.cs
+++ b/LibDescent/Data/Robot.cs
@@ -185,44 +185,44 @@ namespace LibDescent.Data
                     break;
                 case 16:
                     value = Util.Clamp(value, int.MinValue, int.MaxValue, ref clamped);
-                    lighting = new Fix(value);
+                    lighting = Fix.FromRawValue(value);
                     break;
                 case 17:
                     value = Util.Clamp(value, int.MinValue, int.MaxValue, ref clamped);
-                    strength = new Fix(value);
+                    strength = Fix.FromRawValue(value);
                     break;
                 case 18:
                     value = Util.Clamp(value, int.MinValue, int.MaxValue, ref clamped);
-                    mass = new Fix(value);
+                    mass = Fix.FromRawValue(value);
                     break;
                 case 19:
                     value = Util.Clamp(value, int.MinValue, int.MaxValue, ref clamped);
-                    drag = new Fix(value);
+                    drag = Fix.FromRawValue(value);
                     break;
                 case 20:
                     value = (int)(Math.Cos(value * Math.PI / 180.0D) * 65536.0);
                     value = Util.Clamp(value, int.MinValue, int.MaxValue, ref clamped);
-                    field_of_view[curAI] = new Fix(value);
+                    field_of_view[curAI] = Fix.FromRawValue(value);
                     break;
                 case 21:
                     value = Util.Clamp(value, int.MinValue, int.MaxValue, ref clamped);
-                    firing_wait[curAI] = new Fix(value);
+                    firing_wait[curAI] = Fix.FromRawValue(value);
                     break;
                 case 22:
                     value = Util.Clamp(value, int.MinValue, int.MaxValue, ref clamped);
-                    firing_wait2[curAI] = new Fix(value);
+                    firing_wait2[curAI] = Fix.FromRawValue(value);
                     break;
                 case 23:
                     value = Util.Clamp(value, int.MinValue, int.MaxValue, ref clamped);
-                    turn_time[curAI] = new Fix(value);
+                    turn_time[curAI] = Fix.FromRawValue(value);
                     break;
                 case 24:
                     value = Util.Clamp(value, int.MinValue, int.MaxValue, ref clamped);
-                    max_speed[curAI] = new Fix(value);
+                    max_speed[curAI] = Fix.FromRawValue(value);
                     break;
                 case 25:
                     value = Util.Clamp(value, int.MinValue, int.MaxValue, ref clamped);
-                    circle_distance[curAI] = new Fix(value);
+                    circle_distance[curAI] = Fix.FromRawValue(value);
                     break;
                 case 26:
                     value = Util.Clamp(value, sbyte.MinValue, sbyte.MaxValue, ref clamped);

--- a/LibDescent/Data/Ship.cs
+++ b/LibDescent/Data/Ship.cs
@@ -44,25 +44,25 @@ namespace LibDescent.Data
                     expl_vclip_num = data;
                     break;
                 case 3:
-                    mass = new Fix(data);
+                    mass = Fix.FromRawValue(data);
                     break;
                 case 4:
-                    drag = new Fix(data);
+                    drag = Fix.FromRawValue(data);
                     break;
                 case 5:
-                    max_thrust = new Fix(data);
+                    max_thrust = Fix.FromRawValue(data);
                     break;
                 case 6:
-                    reverse_thrust = new Fix(data);
+                    reverse_thrust = Fix.FromRawValue(data);
                     break;
                 case 7:
-                    brakes = new Fix(data);
+                    brakes = Fix.FromRawValue(data);
                     break;
                 case 8:
-                    wiggle = new Fix(data);
+                    wiggle = Fix.FromRawValue(data);
                     break;
                 case 9:
-                    max_rotthrust = new Fix(data);
+                    max_rotthrust = Fix.FromRawValue(data);
                     break;
             }
         }

--- a/LibDescent/Data/VHAMFile.cs
+++ b/LibDescent/Data/VHAMFile.cs
@@ -197,7 +197,7 @@ namespace LibDescent.Data
             for (int i = 0; i < Polymodel.MAX_GUNS; i++)
             {
                 model.gunPoints[i] = robot.gun_points[i];
-                model.gunDirs[i] = new FixVector(65536, 0, 0);
+                model.gunDirs[i] = FixVector.FromRawValues(65536, 0, 0);
                 model.gunSubmodels[i] = robot.gun_submodels[i];
             }
             int[,] jointmapping = new int[10, 5];

--- a/LibDescent/Data/Weapon.cs
+++ b/LibDescent/Data/Weapon.cs
@@ -193,10 +193,10 @@ namespace LibDescent.Data
                     children = (sbyte)(value - 1);
                     break;
                 case 22:
-                    energy_usage = new Fix(value);
+                    energy_usage = Fix.FromRawValue(value);
                     break;
                 case 23:
-                    fire_wait = new Fix(value);
+                    fire_wait = Fix.FromRawValue(value);
                     break;
                 case 24:
                     multi_damage_scale = value;
@@ -205,37 +205,37 @@ namespace LibDescent.Data
                     bitmap = (ushort)value;
                     break;
                 case 26:
-                    blob_size = new Fix(value);
+                    blob_size = Fix.FromRawValue(value);
                     break;
                 case 27:
-                    flash_size = new Fix(value);
+                    flash_size = Fix.FromRawValue(value);
                     break;
                 case 28:
-                    impact_size = new Fix(value);
+                    impact_size = Fix.FromRawValue(value);
                     break;
                 case 29:
-                    strength[index] = new Fix(value);
+                    strength[index] = Fix.FromRawValue(value);
                     break;
                 case 30:
-                    speed[index] = new Fix(value);
+                    speed[index] = Fix.FromRawValue(value);
                     break;
                 case 31:
-                    mass = new Fix(value);
+                    mass = Fix.FromRawValue(value);
                     break;
                 case 32:
-                    drag = new Fix(value);
+                    drag = Fix.FromRawValue(value);
                     break;
                 case 33:
-                    thrust = new Fix(value);
+                    thrust = Fix.FromRawValue(value);
                     break;
                 case 34:
-                    po_len_to_width_ratio = new Fix(value);
+                    po_len_to_width_ratio = Fix.FromRawValue(value);
                     break;
                 case 35:
-                    light = new Fix(value);
+                    light = Fix.FromRawValue(value);
                     break;
                 case 36:
-                    lifetime = new Fix(value);
+                    lifetime = Fix.FromRawValue(value);
                     break;
                 case 37:
                     picture = (ushort)value;
@@ -244,7 +244,7 @@ namespace LibDescent.Data
                     hires_picture = (ushort)value;
                     break;
                 case 39:
-                    damage_radius = new Fix(value);
+                    damage_radius = Fix.FromRawValue(value);
                     break;
             }
         }

--- a/PiggyDump/Editor/Level.cs
+++ b/PiggyDump/Editor/Level.cs
@@ -337,9 +337,9 @@ namespace Descent2Workshop.Editor
 
                         for (int uv = 0; uv < 4; uv++)
                         {
-                            seg.sides[side].uvls[uv].x = new Fix(br.ReadInt16() << 5);
-                            seg.sides[side].uvls[uv].y = new Fix(br.ReadInt16() << 5);
-                            seg.sides[side].uvls[uv].z = new Fix(br.ReadUInt16() << 1);
+                            seg.sides[side].uvls[uv].x = Fix.FromRawValue(br.ReadInt16() << 5);
+                            seg.sides[side].uvls[uv].y = Fix.FromRawValue(br.ReadInt16() << 5);
+                            seg.sides[side].uvls[uv].z = Fix.FromRawValue(br.ReadUInt16() << 1);
                         }
                     }
                     else
@@ -811,7 +811,7 @@ namespace Descent2Workshop.Editor
                 obj.modelInfo.modelNum = 1;
                 obj.modelInfo.textureOverride = -1;
                 obj.moveType = MovementType.Spinning;
-                obj.spinRate = new FixVector(0, (int)(65536 / 1.5), 0);
+                obj.spinRate = FixVector.FromRawValues(0, (int)(65536 / 1.5), 0);
             }
 
             if (obj.type == ObjectType.Powerup && obj.id == 19)
@@ -820,7 +820,7 @@ namespace Descent2Workshop.Editor
                 obj.modelInfo.modelNum = 3;
                 obj.modelInfo.textureOverride = -1;
                 obj.moveType = MovementType.Spinning;
-                obj.spinRate = new FixVector(0, (int)(65536 / 1.5), 0);
+                obj.spinRate = FixVector.FromRawValues(0, (int)(65536 / 1.5), 0);
             }
 
             return obj;
@@ -1075,9 +1075,9 @@ namespace Descent2Workshop.Editor
         private FixVector ReadFixVec(BinaryReader br)
         {
             FixVector vec;
-            vec.x = new Fix(br.ReadInt32());
-            vec.y = new Fix(br.ReadInt32());
-            vec.z = new Fix(br.ReadInt32());
+            vec.x = Fix.FromRawValue(br.ReadInt32());
+            vec.y = Fix.FromRawValue(br.ReadInt32());
+            vec.z = Fix.FromRawValue(br.ReadInt32());
             return vec;
         }
 

--- a/PiggyDump/Editor/LevelTransform.cs
+++ b/PiggyDump/Editor/LevelTransform.cs
@@ -135,8 +135,8 @@ namespace Descent2Workshop.Editor
             {
                 Vector3 translateX = xAxis * xAmount;
                 Vector3 translateY = yAxis * yAmount;
-                FixVector xVecFix = new FixVector((int)(-translateX.X * 65536), (int)(translateX.Y * 65536), (int)(translateX.Z * 65536));
-                FixVector yVecFix = new FixVector((int)(-translateY.X * 65536), (int)(translateY.Y * 65536), (int)(translateY.Z * 65536));
+                FixVector xVecFix = FixVector.FromRawValues((int)(-translateX.X * 65536), (int)(translateX.Y * 65536), (int)(translateX.Z * 65536));
+                FixVector yVecFix = FixVector.FromRawValues((int)(-translateY.X * 65536), (int)(translateY.Y * 65536), (int)(translateY.Z * 65536));
                 foreach (LevelVertex vert in operatedVerts)
                 {
                     vert.location.Add(xVecFix);

--- a/PiggyDump/Editor/Segment.cs
+++ b/PiggyDump/Editor/Segment.cs
@@ -51,12 +51,12 @@ namespace Descent2Workshop.Editor
     {
         //Quake-esque texture projection
         public static FixVector[] texturePlanes = {
-            new FixVector(65536, 0, 0), new FixVector(0, 65536, 0), new FixVector(0, 0, -65536), //Left
-            new FixVector(0, 0, -65536), new FixVector(65536, 0, 0), new FixVector(0, -65536, 0), //Ceiling
-            new FixVector(-65536, 0, 0), new FixVector(0, 65536, 0), new FixVector(0, 0, -65536), //Right
-            new FixVector(0, 0, 65536), new FixVector(65536, 0, 0), new FixVector(0, -65536, 0), //Floor
-            new FixVector(0, -65536, 0), new FixVector(65536, 0, 0), new FixVector(0, 0, -65536), //Back
-            new FixVector(0, 65536, 0), new FixVector(65536, 0, 0), new FixVector(0, 0, -65536), }; //Front
+            FixVector.FromRawValues(65536, 0, 0), FixVector.FromRawValues(0, 65536, 0), FixVector.FromRawValues(0, 0, -65536), //Left
+            FixVector.FromRawValues(0, 0, -65536), FixVector.FromRawValues(65536, 0, 0), FixVector.FromRawValues(0, -65536, 0), //Ceiling
+            FixVector.FromRawValues(-65536, 0, 0), FixVector.FromRawValues(0, 65536, 0), FixVector.FromRawValues(0, 0, -65536), //Right
+            FixVector.FromRawValues(0, 0, 65536), FixVector.FromRawValues(65536, 0, 0), FixVector.FromRawValues(0, -65536, 0), //Floor
+            FixVector.FromRawValues(0, -65536, 0), FixVector.FromRawValues(65536, 0, 0), FixVector.FromRawValues(0, 0, -65536), //Back
+            FixVector.FromRawValues(0, 65536, 0), FixVector.FromRawValues(65536, 0, 0), FixVector.FromRawValues(0, 0, -65536), }; //Front
 
         public SideType type;
         public SegSide sideNum;

--- a/PiggyDump/EditorPanels/EClipPanel.cs
+++ b/PiggyDump/EditorPanels/EClipPanel.cs
@@ -103,15 +103,15 @@ namespace Descent2Workshop.EditorPanels
                 {
                     case "1":
                         int totalTimeFix = (int)(value * 65536);
-                        clip.vc.play_time = new Fix(totalTimeFix);
-                        clip.vc.frame_time = new Fix(totalTimeFix / clip.vc.num_frames);
+                        clip.vc.play_time = Fix.FromRawValue(totalTimeFix);
+                        clip.vc.frame_time = Fix.FromRawValue(totalTimeFix / clip.vc.num_frames);
                         txtEffectFrameSpeed.Text = clip.vc.frame_time.ToString();
                         break;
                     case "2":
-                        clip.vc.light_value = new Fix((int)(value * 65536));
+                        clip.vc.light_value = Fix.FromRawValue((int)(value * 65536));
                         break;
                     case "3":
-                        clip.dest_size = new Fix((int)(value * 65536));
+                        clip.dest_size = Fix.FromRawValue((int)(value * 65536));
                         break;
                     case "4":
                         clip.dest_bm_num = int.Parse(textBox.Text);

--- a/PiggyDump/EditorPanels/VClipPanel.cs
+++ b/PiggyDump/EditorPanels/VClipPanel.cs
@@ -87,12 +87,12 @@ namespace Descent2Workshop.EditorPanels
                 {
                     case "1":
                         int totalTimeFix = (int)(value * 65536);
-                        clip.play_time = new Fix(totalTimeFix);
-                        clip.frame_time = new Fix(totalTimeFix / clip.num_frames);
+                        clip.play_time = Fix.FromRawValue(totalTimeFix);
+                        clip.frame_time = Fix.FromRawValue(totalTimeFix / clip.num_frames);
                         txtAnimFrameSpeed.Text = clip.frame_time.ToString();
                         break;
                     case "2":
-                        clip.light_value = new Fix((int)(value * 65536));
+                        clip.light_value = Fix.FromRawValue((int)(value * 65536));
                         break;
                 }
             }

--- a/PiggyDump/HAMEditor.cs
+++ b/PiggyDump/HAMEditor.cs
@@ -732,7 +732,7 @@ namespace Descent2Workshop
                 {
                     case "1":
                         int totalTimeFix = (int)(value * 65536);
-                        clip.play_time = new Fix(totalTimeFix);
+                        clip.play_time = Fix.FromRawValue(totalTimeFix);
                         break;
                     case "2":
                         clip.filename = textBox.Text.ToCharArray();
@@ -860,10 +860,10 @@ namespace Descent2Workshop
                 switch (textBox.Tag)
                 {
                     case "3":
-                        powerup.size = new Fix((int)(value * 65536.0));
+                        powerup.size = Fix.FromRawValue((int)(value * 65536.0));
                         break;
                     case "4":
-                        powerup.light = new Fix((int)(value * 65536.0));
+                        powerup.light = Fix.FromRawValue((int)(value * 65536.0));
                         break;
                 }
             }

--- a/PiggyDump/ModelRenderer.cs
+++ b/PiggyDump/ModelRenderer.cs
@@ -230,11 +230,7 @@ namespace Descent2Workshop
 
         private FixVector GetFixVector(byte[] data, ref int offset)
         {
-            FixVector res;
-            res.x = new Fix(GetInt(data, ref offset));
-            res.y = new Fix(GetInt(data, ref offset));
-            res.z = new Fix(GetInt(data, ref offset));
-            return res;
+            return FixVector.FromRawValues(GetInt(data, ref offset), GetInt(data, ref offset), GetInt(data, ref offset));
         }
 
         private void Execute(byte[] data, int offset, Polymodel mainModel, Submodel model)


### PR DESCRIPTION
Main changes:

- Instantiating Fix and FixVector classes from raw values now uses "FromRawValue" and "FromRawValues" static methods, respectively. This makes it clearer that there is a difference from the constructors, which create the objects by converting values into 16.16 fixed-point before storing them.
- All code that called into these functions was updated to match (with the exception of Polymodel.ExpandSubmodels, which might have been bugged).
- Added "checked" statements to calls that can potentially overflow. This causes them to throw exceptions if that happens. Not sure that's what _everyone_ wants but my thinking is it beats weird bugs, like FixVector.Mag returning incorrect values for vectors longer than about 256 units. (We may need a separate resolution for that - it seems somewhat limiting.)
- Added cast operators to convert FixVector to/from System.Numerics.Vector3 (which supposedly can support hardware acceleration). Only inbound is implicit to make it harder to accidentally convert away from FixVector which is the intended storage format.