### PR TITLE
RDL/RL2 file write support

### DIFF
--- a/LibDescent/Data/Level/Level.IO.cs
+++ b/LibDescent/Data/Level/Level.IO.cs
@@ -91,7 +91,8 @@ namespace LibDescent.Data
 
         protected void LoadLevel()
         {
-            using (var reader = new BinaryReader(_stream))
+            // Don't dispose of the stream, let the caller do that
+            using (var reader = new BinaryReader(_stream, Encoding.ASCII, true))
             {
                 int signature = reader.ReadInt32();
                 const int expectedSignature = 'P' * 0x1000000 + 'L' * 0x10000 + 'V' * 0x100 + 'L';
@@ -893,7 +894,8 @@ namespace LibDescent.Data
 
         protected void WriteLevel()
         {
-            using (var writer = new BinaryWriter(_stream))
+            // Don't dispose of the stream, let the caller do that
+            using (var writer = new BinaryWriter(_stream, Encoding.ASCII, true))
             {
                 writer.Write(0x504C564C); // signature, "PLVL"
                 writer.Write(LevelVersion);

--- a/LibDescent/Data/Level/Level.IO.cs
+++ b/LibDescent/Data/Level/Level.IO.cs
@@ -892,6 +892,12 @@ namespace LibDescent.Data
         protected abstract ushort GameDataVersion { get; }
         private const int GameDataSize = 143;
 
+        /// <summary>
+        /// The .POF file names to write into the level, for consumers that need it.
+        /// Referenced by (non-robot) objects with a PolyObj render type.
+        /// </summary>
+        public List<string> PofFiles => _pofFiles;
+
         public void Write()
         {
             // Don't dispose of the stream, let the caller do that

--- a/LibDescent/Data/Level/Level.cs
+++ b/LibDescent/Data/Level/Level.cs
@@ -76,6 +76,11 @@ namespace LibDescent.Data
         {
             return new D1LevelLoader(stream).Load();
         }
+
+        public void WriteToStream(Stream stream)
+        {
+            new D1LevelWriter(this, stream).Write();
+        }
     }
 
     public class D2Level : ILevel
@@ -122,6 +127,11 @@ namespace LibDescent.Data
         public static D2Level CreateFromStream(Stream stream)
         {
             return new D2LevelLoader(stream).Load();
+        }
+
+        public void WriteToStream(Stream stream)
+        {
+            new D2LevelWriter(this, stream, false).Write();
         }
     }
 

--- a/LibDescent/Data/Level/Level.cs
+++ b/LibDescent/Data/Level/Level.cs
@@ -74,7 +74,7 @@ namespace LibDescent.Data
 
         public static D1Level CreateFromStream(Stream stream)
         {
-            return new D1LevelLoader(stream).Load();
+            return new D1LevelReader(stream).Load();
         }
 
         public void WriteToStream(Stream stream)
@@ -126,7 +126,7 @@ namespace LibDescent.Data
 
         public static D2Level CreateFromStream(Stream stream)
         {
-            return new D2LevelLoader(stream).Load();
+            return new D2LevelReader(stream).Load();
         }
 
         public void WriteToStream(Stream stream)

--- a/LibDescent/Data/Level/Level.cs
+++ b/LibDescent/Data/Level/Level.cs
@@ -84,7 +84,7 @@ namespace LibDescent.Data
 
         public List<D2Trigger> Triggers { get; } = new List<D2Trigger>();
 
-        public Palette Palette { get; set; }
+        public string PaletteName { get; set; }
 
         public const int DefaultBaseReactorCountdownTime = 30;
 
@@ -122,6 +122,23 @@ namespace LibDescent.Data
         public static D2Level CreateFromStream(Stream stream)
         {
             return new D2LevelLoader(stream).Load();
+        }
+    }
+
+    public static partial class Extensions
+    {
+        // It's not clear why .NET doesn't define this already, but it doesn't.
+        // Remove if that changes.
+        public static int IndexOf<T>(this IReadOnlyList<T> list, T obj)
+        {
+            for (int i = 0; i < list.Count; i++)
+            {
+                if (list[i].Equals(obj))
+                {
+                    return i;
+                }
+            }
+            return -1;
         }
     }
 }

--- a/LibDescent/Tests/BlockTests.cs
+++ b/LibDescent/Tests/BlockTests.cs
@@ -21,14 +21,6 @@ namespace LibDescent.Tests
             blxBlock = ExtendedBlock.CreateFromStream(blxStream);
         }
 
-        private byte[] GetArrayFromResourceStream(string resourceName)
-        {
-            var resourceStream = GetType().Assembly.GetManifestResourceStream(GetType(), resourceName);
-            var memoryStream = new MemoryStream();
-            resourceStream.CopyTo(memoryStream);
-            return memoryStream.ToArray();
-        }
-
         [Test]
         public void TestBlockSegments()
         {
@@ -151,7 +143,7 @@ namespace LibDescent.Tests
             var stream = new MemoryStream();
             Assert.DoesNotThrow(() => blkBlock.WriteToStream(stream));
 
-            var originalFileContents = GetArrayFromResourceStream("test.blk");
+            var originalFileContents = TestUtils.GetArrayFromResourceStream("test.blk");
             var resultingFileContents = stream.ToArray();
             Assert.IsTrue(Enumerable.SequenceEqual(originalFileContents, resultingFileContents));
         }

--- a/LibDescent/Tests/RdlTests.cs
+++ b/LibDescent/Tests/RdlTests.cs
@@ -322,5 +322,16 @@ namespace LibDescent.Tests
             var inbuiltLevel = D1Level.CreateFromStream(stream);
             Assert.IsNotNull(inbuiltLevel);
         }
+
+        [Test]
+        public void TestSaveLevel()
+        {
+            var stream = new MemoryStream();
+            Assert.DoesNotThrow(() => level.WriteToStream(stream));
+
+            var originalFileContents = TestUtils.GetArrayFromResourceStream("test.rdl");
+            var resultingFileContents = stream.ToArray();
+            Assert.That(resultingFileContents, Is.EqualTo(originalFileContents));
+        }
     }
 }

--- a/LibDescent/Tests/Rl2Tests.cs
+++ b/LibDescent/Tests/Rl2Tests.cs
@@ -1,9 +1,6 @@
 ﻿using LibDescent.Data;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.IO;
 
 namespace LibDescent.Tests
 {
@@ -315,6 +312,17 @@ namespace LibDescent.Tests
             Assert.AreEqual(0b00110011001100110011001100110011, level.AnimatedLights[0].Mask);
             Assert.AreEqual((Fix)0.25, level.AnimatedLights[1].TickLength);
             Assert.AreEqual(0b11001100110011001100110011001100, level.AnimatedLights[1].Mask);
+        }
+
+        [Test]
+        public void TestSaveLevel()
+        {
+            var stream = new MemoryStream();
+            Assert.DoesNotThrow(() => level.WriteToStream(stream));
+
+            var originalFileContents = TestUtils.GetArrayFromResourceStream("test.rl2");
+            var resultingFileContents = stream.ToArray();
+            Assert.That(resultingFileContents, Is.EqualTo(originalFileContents));
         }
     }
 }

--- a/LibDescent/Tests/Rl2Tests.cs
+++ b/LibDescent/Tests/Rl2Tests.cs
@@ -252,6 +252,12 @@ namespace LibDescent.Tests
         }
 
         [Test]
+        public void TestPaletteName()
+        {
+            Assert.AreEqual("groupa.256", level.PaletteName);
+        }
+
+        [Test]
         public void TestSecretExit()
         {
             Assert.AreSame(level.Segments[6], level.SecretReturnSegment);

--- a/LibDescent/Tests/TestUtils.cs
+++ b/LibDescent/Tests/TestUtils.cs
@@ -1,0 +1,15 @@
+﻿using System.IO;
+
+namespace LibDescent.Tests
+{
+    static class TestUtils
+    {
+        public static byte[] GetArrayFromResourceStream(string resourceName)
+        {
+            var resourceStream = typeof(TestUtils).Assembly.GetManifestResourceStream(typeof(TestUtils), resourceName);
+            var memoryStream = new MemoryStream();
+            resourceStream.CopyTo(memoryStream);
+            return memoryStream.ToArray();
+        }
+    }
+}

--- a/LibDescent/Tests/TestUtils.cs
+++ b/LibDescent/Tests/TestUtils.cs
@@ -4,9 +4,14 @@ namespace LibDescent.Tests
 {
     static class TestUtils
     {
+        public static Stream GetResourceStream(string resourceName)
+        {
+            return typeof(TestUtils).Assembly.GetManifestResourceStream(typeof(TestUtils), resourceName);
+        }
+
         public static byte[] GetArrayFromResourceStream(string resourceName)
         {
-            var resourceStream = typeof(TestUtils).Assembly.GetManifestResourceStream(typeof(TestUtils), resourceName);
+            var resourceStream = GetResourceStream(resourceName);
             var memoryStream = new MemoryStream();
             resourceStream.CopyTo(memoryStream);
             return memoryStream.ToArray();


### PR DESCRIPTION
This should add the rest of the necessary code to make the LibDescent level classes usable for level editors. The "Palette" property in D2Level has been replaced by "PaletteName" so it can be edited and written to file without loading palettes if necessary.