### PR TITLE
Fix HAM save

### DIFF
--- a/PiggyDump/SaveHandlers/FileSaveHandler.cs
+++ b/PiggyDump/SaveHandlers/FileSaveHandler.cs
@@ -118,7 +118,7 @@ namespace Descent2Workshop.SaveHandlers
 
         public override Stream GetStream()
         {
-            Stream stream = null;
+            stream = null;
             try
             {
                 stream = File.Open(newfilename, FileMode.Create);


### PR DESCRIPTION
Been playing around with the HAM editor a bit, but saving was acting borky -- did some sleuthing and the gist is FileSaveHandler::FinalizeStream was failing to close the stream because FileSaveHandler::GetStream was assigning the stream to a local variable named `stream`, rather than the member variable that FinalizeStream wants to use. Fixed that up and all the save troubles went away, so here, have a PR. ;)